### PR TITLE
fix(ga): use GA ua id for tracking

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -47,7 +47,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "G-8655PJ0K34"
+id = "UA-216672910-1"
 
 # Language configuration
 


### PR DESCRIPTION
Docsy is now only support UA id.